### PR TITLE
Added parameter `trusted=False` to `utils._evaluateExpression`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Changelog
   [gbastien]
 - Adapted code (except, implementer) to be Python3 compatible.
   [gbastien]
+- Added parameter `trusted=False` to `utils._evaluateExpression`, this will use
+  a trusted expression handler instead the restricted python default.
+  [gbastien]
 
 0.11 (2019-05-16)
 -----------------

--- a/buildout.d/versions.cfg
+++ b/buildout.d/versions.cfg
@@ -3,6 +3,7 @@ setuptools = 38.5.1
 zc.buildout = 2.13.2
 ipdb = 0.11
 ipython = 5.7.0
+traitlets = 4.3.3
 
 #zc.recipe.egg = 2.0.0
 #coverage = 3.7.1

--- a/src/collective/behavior/talcondition/tests/test_utils.py
+++ b/src/collective/behavior/talcondition/tests/test_utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+
+from AccessControl import Unauthorized
 from collective.behavior.talcondition import PLONE_VERSION
 from collective.behavior.talcondition.behavior import ITALCondition
 from collective.behavior.talcondition.interfaces import ITALConditionable
@@ -95,3 +97,15 @@ class TestUtils(IntegrationTestCase):
         self.adapted.tal_condition = u'python: context.some_unexisting_method()'
         self.assertFalse(evaluateExpressionFor(self.adapted))
         self.assertRaises(AttributeError, evaluateExpressionFor, self.adapted, raise_on_error=True)
+
+    def test_trusted(self):
+        self.assertRaises(Unauthorized,
+                          _evaluateExpression,
+                          self.portal,
+                          expression='python: context.unrestrictedTraverse("view")',
+                          raise_on_error=True)
+        self.assertTrue(_evaluateExpression(
+            self.portal,
+            expression='python: context.unrestrictedTraverse("view")',
+            raise_on_error=True,
+            trusted=True))


### PR DESCRIPTION
This will use a trusted expression handler instead the restricted python default.  See #MOD-833